### PR TITLE
Fix index page subTitle component font size for reponsive mobile view

### DIFF
--- a/components/reusable/JSSlideUpLink/JSSlideUpLink.styles.ts
+++ b/components/reusable/JSSlideUpLink/JSSlideUpLink.styles.ts
@@ -12,7 +12,7 @@ const slideUp = keyframes`
 `;
 
 export const StyledAnchor = styled.a<{ isIntersecting?: boolean }>`
-  font-size: 1.5vw;
+  font-size: max(1.5vw, 1.4rem);
   font-weight: 600;
   padding: 1em;
   cursor: pointer;

--- a/styles/pageComponentStyles/indexPage.styles.ts
+++ b/styles/pageComponentStyles/indexPage.styles.ts
@@ -109,6 +109,10 @@ export const IndexSubtitle = styled.h2<{ fontSize?: string }>`
   font-size: ${({ fontSize }) => fontSize || "1.1rem"};
   font-weight: 650;
 
+  @media screen and (max-width: 549px) {
+    font-size: 1.15rem;
+  }
+
   @media screen and (min-width: 550px) {
     font-size: ${({ fontSize }) => fontSize || "1.6rem"};
   }


### PR DESCRIPTION
(1) index page SubTitle component's font size is now correspond to various mobile view without text line breaking.
(2) font size of animated link button at the bottom of index page is also changed with css max function 